### PR TITLE
Fix path to askpass

### DIFF
--- a/ssh/operation.vala
+++ b/ssh/operation.vala
@@ -181,7 +181,7 @@ public abstract class Operation : GLib.Object {
         // No terminal for this process
         Posix.setsid();
 
-        Environment.set_variable("SSH_ASKPASS", "%s/ssh-askpass".printf(Config.EXECDIR), false);
+        Environment.set_variable("SSH_ASKPASS", GLib.Path.build_filename(Config.EXECDIR, "ssh-askpass"), false);
 
         // We do screen scraping so we need locale C
         if (Environment.get_variable("LC_ALL") != null)


### PR DESCRIPTION
Right now when I'm trying to execute anything related to askpass I'm getting an error /usr/lib/seahorseseahorse-ssh-askpass: no such file or directory this is because the code is pointing to the wrong path. fixed on this commit.